### PR TITLE
Refactor SinglePublisher class out of access token package

### DIFF
--- a/java/base-client/src/main/java/no/bankaxept/epayment/client/base/SinglePublisher.java
+++ b/java/base-client/src/main/java/no/bankaxept/epayment/client/base/SinglePublisher.java
@@ -1,4 +1,4 @@
-package no.bankaxept.epayment.client.base.accesstoken;
+package no.bankaxept.epayment.client.base;
 
 import java.util.concurrent.Executor;
 import java.util.concurrent.Flow;

--- a/java/base-client/src/main/java/no/bankaxept/epayment/client/base/accesstoken/AccessTokenProcessor.java
+++ b/java/base-client/src/main/java/no/bankaxept/epayment/client/base/accesstoken/AccessTokenProcessor.java
@@ -1,5 +1,6 @@
 package no.bankaxept.epayment.client.base.accesstoken;
 
+import no.bankaxept.epayment.client.base.SinglePublisher;
 import no.bankaxept.epayment.client.base.http.HttpClient;
 import no.bankaxept.epayment.client.base.http.HttpResponse;
 import no.bankaxept.epayment.client.base.http.HttpStatusException;

--- a/java/base-client/src/test/java/no/bankaxept/epayment/client/base/accesstoken/AccessTokenProcessorTest.java
+++ b/java/base-client/src/test/java/no/bankaxept/epayment/client/base/accesstoken/AccessTokenProcessorTest.java
@@ -1,5 +1,6 @@
 package no.bankaxept.epayment.client.base.accesstoken;
 
+import no.bankaxept.epayment.client.base.SinglePublisher;
 import no.bankaxept.epayment.client.base.http.HttpClient;
 import no.bankaxept.epayment.client.base.http.HttpResponse;
 import org.junit.jupiter.api.Test;


### PR DESCRIPTION
This class was very handy, and wasn't really related to access tokens - so I moved it up
