### PR TITLE
Remove asm version

### DIFF
--- a/java/pom.xml
+++ b/java/pom.xml
@@ -32,15 +32,6 @@
                     <version>${maven-surefire-plugin.version}</version>
                     <configuration>
                     </configuration>
-                    <!--As of surefire v.2.22.2, its plexus-java dependency was transitively pulling an older
-                    version of asm 6.2 that did not support Java 17, requiring us to manually provide the version.-->
-                    <dependencies>
-                        <dependency>
-                            <groupId>org.ow2.asm</groupId>
-                            <artifactId>asm</artifactId>
-                            <version>9.1</version>
-                        </dependency>
-                    </dependencies>
                 </plugin>
             </plugins>
         </pluginManagement>


### PR DESCRIPTION
Surefire version is now 3.0.0, which has an updated and compatible asm version. 

<img width="476" alt="image" src="https://github.com/BankAxept/bankaxept-epayment-development-kit/assets/36443669/5366112a-ec3e-44a0-9f4d-3f14c55e5f86">
