### PR TITLE
updated openApi spec; merchant display name is mandatory now.

### DIFF
--- a/openapi/integrator/merchant/bankaxept.yaml
+++ b/openapi/integrator/merchant/bankaxept.yaml
@@ -257,6 +257,7 @@ components:
         - encryptedCardholderAuthenticationData
         - inStore
         - transactionTime
+        - merchantDisplayName
       properties:
         amount:
           $ref: '../components.yaml#/components/schemas/Amount'


### PR DESCRIPTION
merchant display name is mandatory now