### PR TITLE
Add merchant reference as optional field for refund and capture requests

### DIFF
--- a/openapi/integrator/merchant/bankaxept.yaml
+++ b/openapi/integrator/merchant/bankaxept.yaml
@@ -321,6 +321,8 @@ components:
       properties:
         amount:
           $ref: '../components.yaml#/components/schemas/Amount'
+        merchantReference:
+          $ref: '../components.yaml#/components/schemas/merchantReference'
         messageId:
           $ref: '../components.yaml#/components/schemas/messageId'
 
@@ -334,6 +336,8 @@ components:
       properties:
         amount:
           $ref: '../components.yaml#/components/schemas/Amount'
+        merchantReference:
+          $ref: '../components.yaml#/components/schemas/merchantReference'
         messageId:
           $ref: '../components.yaml#/components/schemas/messageId'
         inStore:


### PR DESCRIPTION
Add merchant reference as optional field for refund and capture requests. First step towards making it a requirement to use as request/reply correlation identifier?