### PR TITLE
build: Change project modules versions to project version

### DIFF
--- a/java/pom.xml
+++ b/java/pom.xml
@@ -43,32 +43,32 @@
             <dependency>
                 <groupId>no.bankaxept.epayment</groupId>
                 <artifactId>base-client</artifactId>
-                <version>1.0.4-SNAPSHOT</version>
+                <version>${project.version}</version>
             </dependency>
             <dependency>
                 <groupId>no.bankaxept.epayment</groupId>
                 <artifactId>webflux-client</artifactId>
-                <version>1.0.4-SNAPSHOT</version>
+                <version>${project.version}</version>
             </dependency>
             <dependency>
                 <groupId>no.bankaxept.epayment</groupId>
                 <artifactId>client-test</artifactId>
-                <version>1.0.4-SNAPSHOT</version>
+                <version>${project.version}</version>
             </dependency>
             <dependency>
                 <groupId>no.bankaxept.epayment</groupId>
                 <artifactId>merchant-client</artifactId>
-                <version>1.0.4-SNAPSHOT</version>
+                <version>${project.version}</version>
             </dependency>
             <dependency>
                 <groupId>no.bankaxept.epayment</groupId>
                 <artifactId>token-requestor-client</artifactId>
-                <version>1.0.4-SNAPSHOT</version>
+                <version>${project.version}</version>
             </dependency>
             <dependency>
                 <groupId>no.bankaxept.epayment</groupId>
                 <artifactId>wallet-client</artifactId>
-                <version>1.0.4-SNAPSHOT</version>
+                <version>${project.version}</version>
             </dependency>
             <!-- openapi generation -->
             <dependency>


### PR DESCRIPTION
This will fix the following error in the release PR:

`Error:  Failed to execute goal on project webflux-client: Could not resolve dependencies for project no.bankaxept.epayment:webflux-client:jar:1.0.4: Could not find artifact no.bankaxept.epayment:base-client:jar:1.0.4-SNAPSHOT`