### PR TITLE
Fix: Add ErrorCode as a property to CardEnrolmentResponse 

### DIFF
--- a/openapi/integrator/token-requestor/partner.yaml
+++ b/openapi/integrator/token-requestor/partner.yaml
@@ -183,7 +183,7 @@ components:
 
     ErrorCode:
       type: string
-      example: CARD_NOT_ACTIVATED
+      example: CardNotActivated
       description: |
         Code specifying the result of the operation:
         * EnrolmentOperationFailed - Retryable.

--- a/openapi/integrator/token-requestor/partner.yaml
+++ b/openapi/integrator/token-requestor/partner.yaml
@@ -176,16 +176,39 @@ components:
         * Accepted - Enrolment was accepted.
         * Rejected - Enrolment was rejected.
         * Failed - Enrolment failed.
-        * InvalidFundingPan - No eligible card found.
-        * CardExpired - Card has expired.
-        * CardNotActivated - Card is not activated.
       enum:
         - Accepted
         - Rejected
         - Failed
-        - InvalidFundingPan
-        - CardExpired
-        - CardNotActivated
+
+    ErrorCode:
+      type: string
+      example: Accepted
+      description: |
+        Code specifying the result of the operation:
+        * ENROLMENT_OPERATION_FAILED -
+        * ILLEGAL_OPERATION
+        * TIMEOUT
+        * UNKNOWN_CARD -
+        * CARD_NOT_ACTIVATED -
+        * CARD_EXPIRED - 
+        * CARD_SUSPENDED - 
+        * CARD_REVOKED -
+        * NO_ELIGIBLE_CARDS_FOUND _
+        * FPAN_PROV_COUNT_EXCEEDED -
+        * INVALID_FUNDING_PAN -
+      enum:
+        - Enrolment_Operation_Failed
+        - Illegal_Operation
+        - Timeout
+        - Unknown_Card
+        - Card_Not_Activated
+        - Card_Expired
+        - Card_Suspended
+        - Card_Revoked
+        - No_Eligible_Cards_Found
+        - Fpan_Prov_Count_Exceeded
+        - Invalid_Funding_Pan
 
     TokenUpdateData:
       type: object

--- a/openapi/integrator/token-requestor/partner.yaml
+++ b/openapi/integrator/token-requestor/partner.yaml
@@ -183,32 +183,32 @@ components:
 
     ErrorCode:
       type: string
-      example: Accepted
+      example: CARD_NOT_ACTIVATED
       description: |
         Code specifying the result of the operation:
-        * ENROLMENT_OPERATION_FAILED -
-        * ILLEGAL_OPERATION
-        * TIMEOUT
-        * UNKNOWN_CARD -
-        * CARD_NOT_ACTIVATED -
-        * CARD_EXPIRED - 
-        * CARD_SUSPENDED - 
-        * CARD_REVOKED -
-        * NO_ELIGIBLE_CARDS_FOUND _
-        * FPAN_PROV_COUNT_EXCEEDED -
-        * INVALID_FUNDING_PAN -
+        * EnrolmentOperationFailed - Retryable.
+        * IllegalOperation - Retryable.
+        * Timeout - Retryable.
+        * UnknownCard - Card is not known. Recommend contacting card issuer.
+        * CardNotActivated - Card is not activated for use. Recommend activating card. Often by performing an offline transaction first in the case of a new card.
+        * CardExpired - Card is expired. Recommend updating to a new card. 
+        * CardSuspended - Card is suspended. Recommend contacting card issuer.
+        * CardRevoked - Card is revoked. Recommend contacting card issuer. 
+        * NoEligibleCardsFound - No eligible cards found. Recommend contacting card issuer.
+        * FpanProvCountExceeded - Card enroled too many times. 
+        * InvalidFundingPan - Invalid funding PAN. Recommend contacting card issuer.
       enum:
-        - Enrolment_Operation_Failed
-        - Illegal_Operation
+        - EnrolmentOperationFailed
+        - IllegalOperation
         - Timeout
-        - Unknown_Card
-        - Card_Not_Activated
-        - Card_Expired
-        - Card_Suspended
-        - Card_Revoked
-        - No_Eligible_Cards_Found
-        - Fpan_Prov_Count_Exceeded
-        - Invalid_Funding_Pan
+        - UnknownCard
+        - CardNotActivated
+        - CardExpired
+        - CardSuspended
+        - CardRevoked
+        - NoEligibleCardsFound
+        - FpanProvCountExceeded
+        - InvalidFundingPan
 
     TokenUpdateData:
       type: object

--- a/openapi/integrator/token-requestor/partner.yaml
+++ b/openapi/integrator/token-requestor/partner.yaml
@@ -156,6 +156,8 @@ components:
           $ref: '../components.yaml#/components/schemas/nin'
         status:
           $ref: '#/components/schemas/EnrolmentStatus'
+        errorCode:
+          $ref: '#/components/schemas/ErrorCode'
         paymentToken:
           $ref: '../components.yaml#/components/schemas/PaymentToken'
         accountNumberLastFourDigits:


### PR DESCRIPTION
This adds the ErrorCode as a property, resulting in proper OpenAPI generation.