### PR TITLE
fix: Add error codes for Refund and Capture operations

### DIFF
--- a/openapi/integrator/merchant/partner.yaml
+++ b/openapi/integrator/merchant/partner.yaml
@@ -318,3 +318,24 @@ components:
       maxLength: 6
       description: >-
         A code from the issuer identifying a successful authorisation.
+
+    ErrorCode:
+      type: string
+      example: Declined
+      description: |
+        Code specifying the cause of failure for the Refund or Capture operation:
+        * Unavailable - Retryable.
+        * InitiationFailed - Retryable.
+        * Failed - Not Retryable. Review configuration of integration.
+        * Incomprehensible - Retryable, possible network issue or ongoing incident.
+        * Blocked - Transaction is blocked, recommend contacting issuer.
+        * TransactionNotPermitted - Not permitted, review configuration integration. For example length of time since original transaction.
+        * Declined - Not retryable. Declined by business rules.
+      enum:
+        - Unavailable
+        - InitiationFailed
+        - Failed
+        - Incomprehensible
+        - TransactionNotPermitted
+        - Blocked
+        - Declined

--- a/openapi/integrator/merchant/partner.yaml
+++ b/openapi/integrator/merchant/partner.yaml
@@ -327,8 +327,8 @@ components:
       description: |
         Only provided in Declined scenarios. 
         Code specifying the cause of Decline for the Refund operation:
-        * None - No additional information given. 
         * DeclinedByIssuer - Transaction is declined by Issuer, recommend contacting issuer.
+        * None - No additional information given. 
         * ServiceNotAllowedForMerchant - Not permitted, review configuration integration. For example length of time since original transaction or activation of functionality on BAX account.
       enum:
         - DeclinedByIssuer

--- a/openapi/integrator/merchant/partner.yaml
+++ b/openapi/integrator/merchant/partner.yaml
@@ -334,7 +334,7 @@ components:
         * Failed - Not Retryable. Review configuration of integration.
         * Incomprehensible - Retryable, possible network issue or ongoing incident.
         * Blocked - Transaction is blocked, recommend contacting issuer.
-        * TransactionNotPermitted - Not permitted, review configuration integration. For example length of time since original transaction.
+        * TransactionNotPermitted - Not permitted, review configuration integration. For example length of time since original transaction or activation of functionality on BAX account.
         * Declined - Not retryable. Declined by business rules.
       enum:
         - Unavailable

--- a/openapi/integrator/merchant/partner.yaml
+++ b/openapi/integrator/merchant/partner.yaml
@@ -180,6 +180,8 @@ components:
           $ref: '../components.yaml#/components/schemas/merchantReference'
         status:
           $ref: '#/components/schemas/CaptureStatus'
+        errorCode:
+          $ref: '#/components/schemas/ErrorCode'
         timeCreated:
           type: string
           format: date-time
@@ -204,6 +206,8 @@ components:
           $ref: '../components.yaml#/components/schemas/merchantReference'
         status:
           $ref: '#/components/schemas/RefundStatus'
+        errorCode:
+          $ref: '#/components/schemas/ErrorCode'
         timeCreated:
           type: string
           format: date-time
@@ -323,6 +327,7 @@ components:
       type: string
       example: Declined
       description: |
+        Only provided in Failure/Declined scenarios. 
         Code specifying the cause of failure for the Refund or Capture operation:
         * Unavailable - Retryable.
         * InitiationFailed - Retryable.

--- a/openapi/integrator/merchant/partner.yaml
+++ b/openapi/integrator/merchant/partner.yaml
@@ -180,8 +180,6 @@ components:
           $ref: '../components.yaml#/components/schemas/merchantReference'
         status:
           $ref: '#/components/schemas/CaptureStatus'
-        errorCode:
-          $ref: '#/components/schemas/ErrorCode'
         timeCreated:
           type: string
           format: date-time
@@ -206,8 +204,8 @@ components:
           $ref: '../components.yaml#/components/schemas/merchantReference'
         status:
           $ref: '#/components/schemas/RefundStatus'
-        errorCode:
-          $ref: '#/components/schemas/ErrorCode'
+        declineReason:
+          $ref: '#/components/schemas/RefundDeclineReason'
         timeCreated:
           type: string
           format: date-time
@@ -323,24 +321,16 @@ components:
       description: >-
         A code from the issuer identifying a successful authorisation.
 
-    ErrorCode:
+    RefundDeclineReason:
       type: string
       example: Declined
       description: |
-        Only provided in Failure/Declined scenarios. 
-        Code specifying the cause of failure for the Refund or Capture operation:
-        * Unavailable - Retryable.
-        * InitiationFailed - Retryable.
-        * Failed - Not Retryable. Review configuration of integration.
-        * Incomprehensible - Retryable, possible network issue or ongoing incident.
-        * Blocked - Transaction is blocked, recommend contacting issuer.
-        * TransactionNotPermitted - Not permitted, review configuration integration. For example length of time since original transaction or activation of functionality on BAX account.
-        * Declined - Not retryable. Declined by business rules.
+        Only provided in Declined scenarios. 
+        Code specifying the cause of Decline for the Refund operation:
+        * None - No additional information given. 
+        * DeclinedByIssuer - Transaction is declined by Issuer, recommend contacting issuer.
+        * ServiceNotAllowedForMerchant - Not permitted, review configuration integration. For example length of time since original transaction or activation of functionality on BAX account.
       enum:
-        - Unavailable
-        - InitiationFailed
-        - Failed
-        - Incomprehensible
-        - TransactionNotPermitted
-        - Blocked
-        - Declined
+        - DeclinedByIssuer
+        - None
+        - ServiceNotAllowedForMerchant


### PR DESCRIPTION
We should add error codes to indicate to an integrator what went wrong and how to improve their issues. Similar to how we solved for enrollments in