### PR TITLE
fix: Add merchant cancellation callback API

### DIFF
--- a/java/client-test/src/test/java/no/bankaxept/epayment/client/test/merchant/MerchantClientTest.java
+++ b/java/client-test/src/test/java/no/bankaxept/epayment/client/test/merchant/MerchantClientTest.java
@@ -23,6 +23,7 @@ import java.time.OffsetDateTime;
 import java.time.format.DateTimeFormatter;
 import no.bankaxept.epayment.client.base.RequestStatus;
 import no.bankaxept.epayment.client.merchant.Amount;
+import no.bankaxept.epayment.client.merchant.CancellationRequest;
 import no.bankaxept.epayment.client.merchant.CaptureRequest;
 import no.bankaxept.epayment.client.merchant.CutOffRequest;
 import no.bankaxept.epayment.client.merchant.MerchantClient;
@@ -215,7 +216,11 @@ public class MerchantClientTest extends AbstractBaseClientWireMockTest {
     @Test
     public void success() {
       stubFor(CancelEndpointMapping("payment-id", "1", created()));
-      StepVerifier.create(JdkFlowAdapter.flowPublisherToFlux(client.cancelPayment("payment-id", "1")))
+      StepVerifier.create(JdkFlowAdapter.flowPublisherToFlux(client.cancelPayment(
+          "payment-id",
+              new CancellationRequest().messageId("87a898af-2506-416e-9e99-c7c7b8f3f615"),
+              "1"
+          )))
           .expectNext(RequestStatus.Accepted)
           .verifyComplete();
     }

--- a/java/merchant-client/src/main/java/no/bankaxept/epayment/client/merchant/MerchantClient.java
+++ b/java/merchant-client/src/main/java/no/bankaxept/epayment/client/merchant/MerchantClient.java
@@ -84,12 +84,13 @@ public class MerchantClient {
     );
   }
 
-  public Flow.Publisher<RequestStatus> cancelPayment(String paymentId, String correlationId) {
+  public Flow.Publisher<RequestStatus> cancelPayment(String paymentId, CancellationRequest request, String correlationId) {
     return new MapOperator<>(
         baseClient.post(
             String.format("/v1/payments/%s/cancellation", paymentId),
-            new SinglePublisher<>("", executor),
-            correlationId
+            new SinglePublisher<>(json(request), executor),
+            correlationId,
+            findSimulationHeader(request)
         ),
         HttpResponse::requestStatus
     );

--- a/openapi/integrator/merchant/bankaxept.yaml
+++ b/openapi/integrator/merchant/bankaxept.yaml
@@ -121,6 +121,12 @@ paths:
       parameters:
         - $ref: '../components.yaml#/components/parameters/correlationId'
         - $ref: '../components.yaml#/components/parameters/paymentId'
+      requestBody:
+        required: true
+        content:
+          application/json;charset=UTF-8:
+            schema:
+              $ref: '#/components/schemas/CancellationRequest'
       responses:
         '200':
           $ref: '../components.yaml#/components/responses/200Ok'
@@ -301,6 +307,14 @@ components:
 
     PermissionGrant:
       $ref: '../components.yaml#/components/schemas/PermissionGrant'
+
+    CancellationRequest:
+      type: object
+      required:
+        - messageId
+      properties:
+        messageId:
+          $ref: '../components.yaml#/components/schemas/messageId'
 
     CaptureRequest:
       type: object

--- a/openapi/integrator/merchant/partner.yaml
+++ b/openapi/integrator/merchant/partner.yaml
@@ -179,7 +179,6 @@ components:
         * AuthorisationApproved - Payment was authorised.
         * Rejected - Payment request was rejected.
         * RolledBack - Payment request was rolled back.
-        * Cancelled - Payment request was cancelled.
         * AuthenticationFailed - Authentication validation failed.
         * AuthorisationFailed - Payment authorisation failed.
         * AuthorisationDeclined - Payment authorisation was declined.

--- a/openapi/integrator/merchant/partner.yaml
+++ b/openapi/integrator/merchant/partner.yaml
@@ -33,6 +33,34 @@ paths:
         '503':
           $ref: '../components.yaml#/components/responses/503Error'
 
+  /v1/payments/cancellations:
+    description: Response to a cancellation request
+    parameters:
+      - $ref: '../components.yaml#/components/parameters/correlationId'
+    post:
+      operationId: cancellationResponse
+      requestBody:
+        required: true
+        content:
+          application/json;charset=UTF-8:
+            schema:
+              $ref: '#/components/schemas/CancellationResponse'
+      responses:
+        '200':
+          $ref: '../components.yaml#/components/responses/200Ok'
+        '201':
+          $ref: '../components.yaml#/components/responses/201Ok'
+        '400':
+          $ref: '../components.yaml#/components/responses/400Error'
+        '409':
+          $ref: '../components.yaml#/components/responses/409Error'
+        '422':
+          $ref: '../components.yaml#/components/responses/422Error'
+        '500':
+          $ref: '../components.yaml#/components/responses/500Error'
+        '503':
+          $ref: '../components.yaml#/components/responses/503Error'
+
   /v1/payments/captures:
     description: Response to a capture request
     parameters:
@@ -159,10 +187,26 @@ components:
         - AuthorisationApproved
         - Rejected
         - RolledBack
-        - Cancelled
         - AuthenticationFailed
         - AuthorisationFailed
         - AuthorisationDeclined
+
+    CancellationResponse:
+      type: object
+      required:
+        - messageId
+        - paymentId
+        - merchantReference
+        - status
+      properties:
+        messageId:
+          $ref: '../components.yaml#/components/schemas/messageId'
+        paymentId:
+          $ref: '../components.yaml#/components/schemas/paymentId'
+        merchantReference:
+          $ref: '../components.yaml#/components/schemas/merchantReference'
+        status:
+          $ref: '#/components/schemas/CancellationStatus'
 
     CaptureResponse:
       type: object
@@ -267,6 +311,19 @@ components:
         debitReversalCount:
           type: integer
           format: int64
+
+    CancellationStatus:
+      type: string
+      example: Approved
+      description: |
+        Code specifying the result of the operation:
+        * Approved - Cancellation request was approved.
+        * Declined - Cancellation request was declined.
+        * Failed - Cancellation request failed.
+      enum:
+        - Approved
+        - Declined
+        - Failed
 
     CaptureStatus:
       type: string


### PR DESCRIPTION
* Add merchant cancellation callback API `/v1/payments/cancellations`
* Add `CancellationRequest` as required request body to the BankAxept cancellation API `/v1/payments/{paymentId}/cancellation`
* Remove PaymentStatus#Cancelled