### PR TITLE
Rename request field in card eligibility endpoint

### DIFF
--- a/java/client-test/src/test/java/no/bankaxept/epayment/client/test/tokenrequestor/TokenRequestorClientIT.java
+++ b/java/client-test/src/test/java/no/bankaxept/epayment/client/test/tokenrequestor/TokenRequestorClientIT.java
@@ -37,7 +37,6 @@ public class TokenRequestorClientIT {
 
   private Flow.Publisher<RequestStatus> enrolCardRequest(TokenRequestorClient client) {
     var correlationId = UUID.randomUUID().toString();
-    System.out.println("Correlation id: " + correlationId);
     return client.enrolCard(new EnrolCardRequest(), correlationId);
   }
 

--- a/java/client-test/src/test/java/no/bankaxept/epayment/client/test/tokenrequestor/TokenRequestorClientTest.java
+++ b/java/client-test/src/test/java/no/bankaxept/epayment/client/test/tokenrequestor/TokenRequestorClientTest.java
@@ -88,7 +88,7 @@ public class TokenRequestorClientTest extends AbstractBaseClientWireMockTest {
 
   private EligibilityRequest createCardEligibilityRequest() {
     return new EligibilityRequest()
-        .encryptedEnrolmentData(encryptedExampleData);
+        .encryptedCardholderAuthenticationData(encryptedExampleData);
   }
 
   private MappingBuilder DeletionEndpoint(ResponseDefinitionBuilder responseBuilder) {
@@ -119,7 +119,7 @@ public class TokenRequestorClientTest extends AbstractBaseClientWireMockTest {
     return post(urlPathEqualTo("/v1/card-eligibility"))
         .withHeader("Authorization", new EqualToPattern(bearerToken()))
         .withHeader("X-Correlation-Id", new EqualToPattern(someCorrelationId))
-        .withRequestBody(matchingJsonPath("encryptedEnrolmentData", equalTo(encryptedExampleData)))
+        .withRequestBody(matchingJsonPath("encryptedCardholderAuthenticationData", equalTo(encryptedExampleData)))
         .willReturn(responseBuilder);
   }
 

--- a/openapi/integrator/token-requestor/bankaxept.yaml
+++ b/openapi/integrator/token-requestor/bankaxept.yaml
@@ -146,9 +146,9 @@ components:
     EligibilityRequest:
       type: object
       required:
-        - encryptedEnrolmentData
+        - encryptedCardholderAuthenticationData
       properties:
-        encryptedEnrolmentData:
+        encryptedCardholderAuthenticationData:
           $ref: '#/components/schemas/encryptedEnrolmentCardholderAuthenticationData'
 
     EnrolmentCardholderAuthenticationData:


### PR DESCRIPTION
Renames the request field in the card eligibility endpoint to `encryptedCardholderAuthenticationData` for consistency with enrolment request