### PR TITLE
Create networkReference for capture and refund requests

### DIFF
--- a/openapi/integrator/components.yaml
+++ b/openapi/integrator/components.yaml
@@ -278,6 +278,12 @@ components:
         A unique identifier that guarantees message idempotency.
       type: string
       example: "74313af1-e2cc-403f-85f1-6050725b01b6"
+    networkReference:
+      description: >-
+        The network reference is a unique identifier for the transaction operation in the network.
+      type: string
+      example: "74313af1-e2cc-403f-85f1-6050725b01b6"
+      maxLength: 100
     pan:
       type: string
       pattern: '^[0-9]{19}$'

--- a/openapi/integrator/merchant/bankaxept.yaml
+++ b/openapi/integrator/merchant/bankaxept.yaml
@@ -326,6 +326,8 @@ components:
           $ref: '../components.yaml#/components/schemas/Amount'
         messageId:
           $ref: '../components.yaml#/components/schemas/messageId'
+        networkReference:
+          $ref: '../components.yaml#/components/schemas/networkReference'
 
     RefundRequest:
       type: object
@@ -341,6 +343,8 @@ components:
           $ref: '../components.yaml#/components/schemas/messageId'
         inStore:
           $ref: '#/components/schemas/inStore'
+        networkReference:
+          $ref: '../components.yaml#/components/schemas/networkReference'
         transactionTime:
           type: string
           format: date-time
@@ -381,4 +385,3 @@ components:
       type: boolean
       default: false
       example: true
-


### PR DESCRIPTION
We need to add a reference that is available downstream in the network that is defined by the integrator/merchant.