### PR TITLE
Add BANK_NOT_ENROLLED error code to card eligiibility check

### DIFF
--- a/openapi/integrator/token-requestor/bankaxept.yaml
+++ b/openapi/integrator/token-requestor/bankaxept.yaml
@@ -211,4 +211,5 @@ components:
         Describes if the eligibility check failed due to non-eligible card or system failure.
       enum:
         - NON_ELIGIBLE
+        - BANK_NOT_ENROLLED
         - FAILED


### PR DESCRIPTION
Includes a new `BANK_NOT_ENROLLED` error code to failed card eligibility requests, when a bank has not enrolled with ePayment.